### PR TITLE
Making use of global variables & also the RequestHandler Interface.

### DIFF
--- a/src/api/controllers/users.controllers.ts
+++ b/src/api/controllers/users.controllers.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import asynchandler from "express-async-handler"
 import { StatusCodes } from "http-status-codes";
-import AppError from "@/utils/appErrors";
 import { plainToInstance } from "class-transformer";
 import { ExtendRequest } from "@/interfaces/extendRequest.interface";
 

--- a/src/api/db/user.entity.ts
+++ b/src/api/db/user.entity.ts
@@ -49,7 +49,7 @@ export class User {
   @Column({ type: "varchar", length: 255, nullable: false })
   transaction_pin: string;
 
-  @Column({ type: "varchar", unique: true, length: 255, nullable: false })
+  @Column({ type: "varchar", unique: true, length: 255, nullable: true })
   nin: string;
 
   @Column({ type: "varchar", unique: true, length: 255, nullable: false })

--- a/src/api/helpers/configs/db.config.ts
+++ b/src/api/helpers/configs/db.config.ts
@@ -18,8 +18,8 @@ if (process.env.NODE_ENV === "test") {
 
 log.info(`Current Environment: ${process.env.NODE_ENV} Environment`);
 
-const isDevelopment = process.env.NODE_ENV;
-const synchronize = isDevelopment ? true : false;
+const isDevelopment = process.env.NODE_ENV === "development";
+const synchronize = isDevelopment;
 
 const {
   DB_HOST,
@@ -49,8 +49,12 @@ export const AppDataSource = new DataSource({
     SettlementAcct,
     UserTransactionModel,
   ],
-  logging: false,
-  synchronize: synchronize
+  // logging: false,
+  logging: ["error", "warn", "schema"],
+  synchronize: synchronize,
+  ssl: process.env.NODE_ENV === "production" ? {
+    rejectUnauthorized: false
+  } : false
 });
 
 

--- a/src/api/helpers/interfaces/appError.interface.ts
+++ b/src/api/helpers/interfaces/appError.interface.ts
@@ -1,0 +1,17 @@
+interface AppErrorInterface extends Error {
+    status?: string;
+    isOperational?: boolean;
+    statusCode?: number;
+};
+
+interface AppErrorConstructor {
+    new(messae: string, status?: string, isOperational?: boolean, statusCode?: number):AppErrorInterface
+};
+
+declare global {
+    var AppError: AppErrorConstructor;
+}
+
+export {
+    AppErrorInterface
+}

--- a/src/api/helpers/middlewares/authMiddleware.ts
+++ b/src/api/helpers/middlewares/authMiddleware.ts
@@ -1,5 +1,5 @@
 import ExpressAsync from "express-async-handler";
-import {  Response, NextFunction } from "express";
+import {  Response, NextFunction, RequestHandler } from "express";
 
 import { User } from "@/db/user.entity";
 import { AppDataSource } from "@/configs/db.config";
@@ -7,8 +7,8 @@ import { ExtendRequest } from "@/interfaces/extendRequest.interface";
 
 const UserRepository = AppDataSource.getRepository(User);
 
-export const protect = ExpressAsync(
-    async (req: ExtendRequest, res: Response, next: NextFunction) => {
+export const protect: RequestHandler = ExpressAsync(
+    async (req: ExtendRequest, res, next) => {
 
         // 1. check if the session exists & has a valid user ID
         if (!req.session || !req.session.userId) {

--- a/src/api/helpers/middlewares/authMiddleware.ts
+++ b/src/api/helpers/middlewares/authMiddleware.ts
@@ -2,9 +2,8 @@ import ExpressAsync from "express-async-handler";
 import {  Response, NextFunction } from "express";
 
 import { User } from "@/db/user.entity";
-import AppError from "@/utils/appErrors";
 import { AppDataSource } from "@/configs/db.config";
-import { ExtendRequest, ExtendResponse } from "@/interfaces/extendRequest.interface";
+import { ExtendRequest } from "@/interfaces/extendRequest.interface";
 
 const UserRepository = AppDataSource.getRepository(User);
 

--- a/src/api/helpers/middlewares/errHandler.ts
+++ b/src/api/helpers/middlewares/errHandler.ts
@@ -12,7 +12,7 @@ const globalErrorHandler = (
   const statusCode = err.statusCode || StatusCodes.INTERNAL_SERVER_ERROR;
   const status = err.status || "error" || "Error";
 
-  // Check if it's an operational erroror a programming error
+  // Check if it's an operational error or a programming error
   if (err.isOperational) {
     res.status(statusCode).json({
       status,

--- a/src/api/helpers/queues/wallet.queues.ts
+++ b/src/api/helpers/queues/wallet.queues.ts
@@ -7,7 +7,6 @@ import { Worker, Queue, Job, QueueEvents, ConnectionOptions } from "bullmq";
 import { User } from "@/db/user.entity";
 import { UserWallet } from "@/db/wallet.entity";
 import redisModule from "@/configs/redis.config";
-import AppError from "@/utils/appErrors";
 import { AppDataSource } from "@/configs/db.config";
 import {
     virtualAccountPayload as VANPayload,

--- a/src/api/helpers/utils/appErrors.ts
+++ b/src/api/helpers/utils/appErrors.ts
@@ -1,4 +1,6 @@
-class AppError extends Error {
+import { AppErrorInterface } from "@/interfaces/appError.interface"
+
+class AppError extends Error implements AppErrorInterface {
   constructor(public message: string, public status?: string ,
     public isOperational?: boolean, public statusCode?: number) {
 
@@ -7,12 +9,20 @@ class AppError extends Error {
 
     // Set additional properties for the error
     this.statusCode = statusCode; // HTTP status code
+    
     this.status = `${statusCode}`.startsWith("4") ? "fail" : "error"; // Status string: "fail" for 4xx codes, "error" for others
+
     this.isOperational = true; // Indicates whether the error is operational (i.e. caused by user input) or a programming error
 
     // Capture the stack trace for debugging
     Error.captureStackTrace(this, this.constructor);
   }
-}
+};
+
+declare global {
+  var AppError: typeof AppError;
+};
+
+globalThis.AppError = AppError;
 
 export default AppError;

--- a/src/api/services/users.service.ts
+++ b/src/api/services/users.service.ts
@@ -2,7 +2,6 @@ import * as bcrypt from "bcryptjs";
 import crypto from "crypto"
 import { Service } from "typedi";
 
-import AppError from "@/utils/appErrors";
 import redisModule from "@/configs/redis.config";
 import { AppDataSource } from "@/configs/db.config";
 import { EmailJobData } from "@/interfaces/email.interface";


### PR DESCRIPTION
on this recent PR I decided to make the AppError a global variable that would be easily accessible to all modules within the serverside of this application. This way there won't be any need for `import AppErro from @/utils/appErrors.ts` see the module to view the changes made. Finally testing how to use the RequestHandler interface on the protect Middleware.